### PR TITLE
Column widths

### DIFF
--- a/docs/components/filterable-table.md
+++ b/docs/components/filterable-table.md
@@ -25,7 +25,6 @@ sidebar: auto
 | `id`            | `string`  |             | `""`          |
 | `items`         | `array`   |             | `[]`          |
 | `itemsPerPage`  | `number`  |             | `2`           |
-| `optionsMerged` | `object`  |             | `{}`          |
 | `totalItems`    | `number`  |             | `5`           |
 | `totalPages`    | `number`  |             | `3`           |
 

--- a/src/components/filterable-table/FilterableTable.vue
+++ b/src/components/filterable-table/FilterableTable.vue
@@ -10,7 +10,6 @@
     <div class="table-head">
       <table-head 
         :headings="headings"
-        :options="optionsMerged"
         :table-id="id"
       />
     </div>
@@ -94,7 +93,6 @@ export default {
       filters: [],
       id: '',
       items: [],
-      optionsMerged: {},
       totalItems: 5,
       totalPages: 3
     }

--- a/src/components/filterable-table/TableHead.vue
+++ b/src/components/filterable-table/TableHead.vue
@@ -27,10 +27,14 @@
 <script>
 import TableHeading from './TableHeading.vue'
 
+import mixinColumns from './mixins/mixin-columns'
+
 export default {
   name: 'TableHead',
 
   components: { TableHeading },
+
+  mixins: [mixinColumns],
 
   props: {
     headings: {
@@ -53,19 +57,11 @@ export default {
   computed: {
     cssVariables () {
       return {
-        'grid-template-columns': `repeat(${this.columnsCount}, 1fr)`,
+        'grid-template-columns': this.gridColumnsCss,
         'grid-columns': this.gridColumnsCss, // IE11
       }
     },
-    gridColumnsCss () {
-      const cols = []
 
-      for (let i=0; i < this.columnsCount; i++) {
-        cols.push('1fr')
-      }
-
-      return cols.join(' ')
-    },
     columnsCount () {
       return Object.keys(this.headings).length + 1
     },

--- a/src/components/filterable-table/TableRow.vue
+++ b/src/components/filterable-table/TableRow.vue
@@ -41,10 +41,14 @@
 <script>
 import SvgArrow from './svgs/SvgArrow.vue'
 
+import mixinColumns from './mixins/mixin-columns'
+
 export default {
   name: "row",
 
   components: { SvgArrow },
+
+  mixins: [mixinColumns],
 
   props: {
     item: {
@@ -60,7 +64,7 @@ export default {
   computed: {
     cssVariablesAndStyles () {
       return {
-        'grid-template-columns': `repeat(${this.columnsCount}, 1fr)`,
+        'grid-template-columns': this.gridColumnsCss,
         'grid-columns': this.gridColumnsCss, // IE11
         '--bg-color-1': this.config.rows.bgColor1,
         '--bg-color-2': this.config.rows.bgColor2,
@@ -70,15 +74,6 @@ export default {
         '--border-width': this.config.rows.borderWidth,
         '--button-hover-color': this.config.rows.buttonHoverColor
       }
-    },
-    gridColumnsCss () {
-      const cols = []
-
-      for (let i=0; i < this.columnsCount; i++) {
-        cols.push('1fr')
-      }
-
-      return cols.join(' ')
     },
     columnsCount () {
       return Object.keys(this.item.cells).length + 1

--- a/src/components/filterable-table/constants.js
+++ b/src/components/filterable-table/constants.js
@@ -102,6 +102,9 @@ export const DEFAULT_OPTIONS = {
     textTitle: '',
     textItems: ''
   },
+  columns: {
+    widths: [2, 2, 1, 1, 1, 1, 1, 1], // Length = attributes.length + 1
+  },
   rows: {
     bgColor1: '#ffffff',
     bgColor2: '#f4f4f4',

--- a/src/components/filterable-table/mixins/mixin-columns.js
+++ b/src/components/filterable-table/mixins/mixin-columns.js
@@ -1,0 +1,43 @@
+export default {
+  computed: {
+    columnsConfig () {
+      return this.$store.getters['filterableTable/options'](this.tableId).columns
+    },
+
+    gridColumnsCss () {
+      if (!('columnsCount' in this)) {
+        console.error(`columnsCount is not implemented for ${this.$options.name}`)
+
+        return ''
+      } else if (this.hasColumnWidths) {
+        return this.gridColumnWidthFromConfig
+      }
+
+      return this.gridEvenColumnsCss
+    },
+
+    hasColumnWidths () {
+      return this.columnsConfig.widths && this.columnsConfig.widths.length
+    },
+
+    gridColumnWidthFromConfig () {
+      if (this.columnsConfig.widths.length !== this.columnsCount) {
+        console.warn(`columnsConfig.widths must have the same length as the number of columns: ${this.columnsCount}`)
+
+        return this.gridEvenColumnsCss
+      }
+      
+      return this.columnsConfig.widths.map(x => `${x}fr`).join(' ')
+    },
+
+    gridEvenColumnsCss () {
+      const cols = []
+
+      for (let i=0; i < this.columnsCount; i++) {
+        cols.push('1fr')
+      }
+
+      return cols.join(' ')
+    }
+  }
+}


### PR DESCRIPTION
Merge after #18 

[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/wcmc-components/tickets/6)

Passing columns: { widths: [...] } within the options object will configure the column widths. The values are numeric and proportional. It does not currently support enter absolute values e.g. in px. Let me know if it needs to do that in someway.

If the config isn't the right number of columns or is not present, it will fallback to even column widths.