### PR TITLE
Feat/optional more content button

### DIFF
--- a/dev/Serve.vue
+++ b/dev/Serve.vue
@@ -6,10 +6,14 @@
     
     <filterable-table
       endpoint-download="/"
+    >
+    <!-- 
+      Example of an options prop that would disable the "show more content" column for the whole table
       :options="{ 
         hideMoreContentColumn: true
       }"
-    >
+    -->
+
     <!-- 
       <template #sort-icon>
         <span>This element is used as the sorting icon now!</span>

--- a/dev/Serve.vue
+++ b/dev/Serve.vue
@@ -6,6 +6,9 @@
     
     <filterable-table
       endpoint-download="/"
+      :options="{ 
+        hideMoreContentColumn: true
+      }"
     >
     <!-- 
       <template #sort-icon>

--- a/src/components/filterable-table/FilterableTable.vue
+++ b/src/components/filterable-table/FilterableTable.vue
@@ -140,7 +140,8 @@ export default {
       isSortable: 'isSortable',
       requestedPage: 'getRequestedPage',
       selectedFilterOptions: 'getSelectedFilterOptions',
-      selectedSort: 'getSelectedSort'
+      selectedSort: 'getSelectedSort',
+      isMoreContentColumnDisplayed: 'isMoreContentColumnDisplayed'
     }),
 
     cssVariables () {
@@ -237,9 +238,12 @@ export default {
     },
 
     getTotalTableColumns () {
-      // Add an additional column for the "View more" button
-      if (this.headings.length > 0) {
+      if (this.headings.length < 1) { return }
+
+      if (this.isMoreContentColumnDisplayed(this.id)) {
         this.totalColumns = this.headings.length + 1
+      } else {
+        this.totalColumns = this.headings.length
       }
     },
 

--- a/src/components/filterable-table/TableHead.vue
+++ b/src/components/filterable-table/TableHead.vue
@@ -17,6 +17,7 @@
       
       <!-- empty heading for 'more content' button -->
       <table-heading
+        v-if="this.isMoreContentColumnDisplayed(this.tableId)"
         :tableId="tableId"
         :style="`grid-column: ${totalColumns}`"
       />
@@ -25,9 +26,11 @@
 </template>
 
 <script>
+import { createNamespacedHelpers } from 'vuex'
 import TableHeading from './TableHeading.vue'
-
 import mixinColumns from './mixins/mixin-columns'
+
+const { mapGetters } = createNamespacedHelpers('filterableTable')
 
 export default {
   name: 'TableHead',
@@ -41,10 +44,12 @@ export default {
       required: true,
       type: Array
     },
+
     tableId: {
       required: true,
       type: Number,
     },
+
     totalColumns: {
       required: true,
       type: Number,
@@ -59,6 +64,8 @@ export default {
   },
 
   computed: {
+    ...mapGetters(['isMoreContentColumnDisplayed']),
+
     cssVariables () {
       return {
         'grid-template-columns': this.gridColumnsCss,

--- a/src/components/filterable-table/TableRow.vue
+++ b/src/components/filterable-table/TableRow.vue
@@ -40,6 +40,7 @@
     </div>
 
     <span
+      v-if="this.isMoreContentColumnDisplayed(this.tableId)" 
       class="cell"
       :style="`grid-column: ${totalColumns}`"
     >
@@ -104,7 +105,10 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['options']),
+    ...mapGetters([
+      'options',
+      'isMoreContentColumnDisplayed'
+    ]),
 
     cssVariablesAndStyles () {
       return {

--- a/src/components/filterable-table/constants.js
+++ b/src/components/filterable-table/constants.js
@@ -182,7 +182,7 @@ export const DUMMY_DATA = {
   ],
   items: [
     {
-      pageUrl: false,
+      pageUrl: 'http://google.com',
       cells: [
         {
           name: 'attribute_1',
@@ -237,7 +237,7 @@ export const DUMMY_DATA = {
       ]
     },
     {
-      pageUrl: false,
+      pageUrl: '',
       cells: [
         {
           name: 'attribute_1',
@@ -291,7 +291,7 @@ export const DUMMY_DATA = {
       ]
     },
     {
-      pageUrl: false,
+      pageUrl: '',
       cells: [
         {
           name: 'attribute_1',

--- a/src/components/filterable-table/constants.js
+++ b/src/components/filterable-table/constants.js
@@ -4,7 +4,7 @@ export const DEFAULT_OPTIONS = {
   columns: {
     widths: ['1fr', '1fr', '300px', '1fr', '1fr', '100px'] // widths.length = attributes.length + 1
   },
-  hideMoreContentColumn: true,
+  hideMoreContentColumn: false,
   download: {
     bgColor: '#aaa',
     bgColorHover: UNEP_WCMC_BLUE,

--- a/src/components/filterable-table/constants.js
+++ b/src/components/filterable-table/constants.js
@@ -4,6 +4,7 @@ export const DEFAULT_OPTIONS = {
   columns: {
     widths: ['1fr', '1fr', '300px', '1fr', '1fr', '100px'] // widths.length = attributes.length + 1
   },
+  hideMoreContentColumn: true,
   download: {
     bgColor: '#aaa',
     bgColorHover: UNEP_WCMC_BLUE,
@@ -181,7 +182,7 @@ export const DUMMY_DATA = {
   ],
   items: [
     {
-      pageUrl: 'http://google.com',
+      pageUrl: false,
       cells: [
         {
           name: 'attribute_1',
@@ -236,7 +237,7 @@ export const DUMMY_DATA = {
       ]
     },
     {
-      pageUrl: '',
+      pageUrl: false,
       cells: [
         {
           name: 'attribute_1',
@@ -290,7 +291,7 @@ export const DUMMY_DATA = {
       ]
     },
     {
-      pageUrl: '',
+      pageUrl: false,
       cells: [
         {
           name: 'attribute_1',

--- a/src/components/filterable-table/store.js
+++ b/src/components/filterable-table/store.js
@@ -44,7 +44,11 @@ export const storeFilterableTable = {
 
     getSelectedSort: state => id => {
       return state.tables[id].selectedSort
-    }
+    },
+    
+    isMoreContentColumnDisplayed: state => id => {
+      return !state.tables[id].options.hideMoreContentColumn
+    },
   },
 
   actions: {


### PR DESCRIPTION
## feat: hide "more content" column

A new key has been added to the Filterable Table's options prop: `hideMoreContentColumn`. The component now refers to this whenever dealing with table headings or columns in the "more content column"