### PR TITLE
feat: implement custom sortability

### DIFF
--- a/dev/Serve.vue
+++ b/dev/Serve.vue
@@ -11,6 +11,16 @@
       Example of an options prop that would disable the "show more content" column for the whole table
       :options="{ 
         hideMoreContentColumn: true
+
+        Example of the sortable property in the options prop that sets every column as sortable by default
+        sortable: true  // if some column should not be sortable, in the project using the table set the 
+                         'sortable' key in the table_attr property of the model (the column) to false.
+
+        Example of the sortable property in the options prop that sets every column as not sortable by default
+        sortable: false  // or don't set anything, it will be false by default. If some column should be 
+                            sortable, in the project using the table set the 'sortable' key in the table_attr
+                            property of the model (the column) to true.
+
       }"
     -->
 

--- a/src/components/filterable-table/TableHeading.vue
+++ b/src/components/filterable-table/TableHeading.vue
@@ -90,8 +90,10 @@ export default {
     tableIsSortable () { return this.options.sortable },
 
     columnIsSortable () { 
-      return this.tableIsSortable ? !this.heading.isNotSortable : this.heading.isSortable
+      return this.heading.sortable === null ? this.tableIsSortable : this.heading.sortable
     }
+
+
   },
 
   methods: {

--- a/src/components/filterable-table/TableHeading.vue
+++ b/src/components/filterable-table/TableHeading.vue
@@ -15,7 +15,7 @@
       />
 
       <div
-        v-if="tableIsSortable"
+        v-if="columnIsSortable"
         class="sorting-toggle"
         @click="sortColumn"
       >
@@ -88,6 +88,10 @@ export default {
     table () { return this.tables[this.tableId] },
 
     tableIsSortable () { return this.options.sortable },
+
+    columnIsSortable () { 
+      return this.tableIsSortable ? !this.heading.isNotSortable : this.heading.isSortable
+    }
   },
 
   methods: {


### PR DESCRIPTION
This PR allows to default the whole table as : 

- `sortable` and then pick and choose which column cannot be sortable. In option, set sortable to `true` and in the model, `table_attr` needs to have sortable set to `false` if you want that columns NOT to be sortable.

- `not sortable` and then pick and choose which column can be sortable. In option, set sortable to `false` (or do not set sortable at all) and in the model, `table_attr` needs to have sortable set to `true` if you want that columns to be sortable.