### PR TITLE
fix: order table edit cells to fix styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.2.4
+
+- Added:
+  - Edit and archive buttons to table rows
+  - Archived styling for rows that are archived
+
 ### 2.2.3
 
 - Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added:
   - Edit and archive buttons to table rows
   - Archived styling for rows that are archived
+  - Configure whether edit and archive columns are shown via keys in the options prop of the FilterableTable. See README.md for more details about table props.
 
 ### 2.2.3
 

--- a/docs/components/filterable-table.md
+++ b/docs/components/filterable-table.md
@@ -24,11 +24,6 @@ sidebar: auto
 | `hideMoreContentColumn` | `Boolean` | Configures whether the more content column/button is displayed. Default is false. |
 | `more...`               | `type`    | Continue to add to this...     |
 
-columns: 
-showArchived: true,
-showEdit: true,
-hideMoreContentColumn: false,
-
 ## Data
 
 | Name            | Type      | Description | Initial value |

--- a/docs/components/filterable-table.md
+++ b/docs/components/filterable-table.md
@@ -14,6 +14,21 @@ sidebar: auto
 | `filter-array`      | `Array`  |             |
 | `options`           | `Object` | &nbsp;      |
 
+### Options
+
+| Name                    | Type      | Description |
+| ----------------------- | --------- | ----------- |
+| `columns`               | `Array`   | Array of column widths passed to css. Must equal the number of displayed columns. |
+| `showArchived`          | `Boolean` | Configures whether the archive button is displayed. Default is false. |
+| `showEdit`              | `Boolean` | Configures whether the edit button is displayed. Default is false. |
+| `hideMoreContentColumn` | `Boolean` | Configures whether the more content column/button is displayed. Default is false. |
+| `more...`               | `type`    | Continue to add to this...     |
+
+columns: 
+showArchived: true,
+showEdit: true,
+hideMoreContentColumn: false,
+
 ## Data
 
 | Name            | Type      | Description | Initial value |

--- a/src/components/filterable-table/TableRow.vue
+++ b/src/components/filterable-table/TableRow.vue
@@ -197,7 +197,7 @@ export default {
       }
 
       if (this.adminButtonsCount === 2) {
-        columnIndex -= (type === 'edit' ? 1 : 0)
+        columnIndex -= (type === 'archive' ? 1 : 0)
       }
 
       return columnIndex


### PR DESCRIPTION
Tiny fix that prevents css grid seeming to add a second row, or something similar. Also just makes more sense as the column ordering matches the order of the elements in the template. (Archive column before edit column)