### PR TITLE
Fix/56 archived row bug

### DIFF
--- a/src/components/filterable-table/ArchiveButton.vue
+++ b/src/components/filterable-table/ArchiveButton.vue
@@ -26,10 +26,12 @@ export default {
       type: String,
       required: true
     },
+
     archived: {
       type: Boolean,
       required: true
     },
+
     recordId: {
       type: Number,
       required: true

--- a/src/components/filterable-table/FilterableTable.vue
+++ b/src/components/filterable-table/FilterableTable.vue
@@ -161,7 +161,6 @@ export default {
   },
 
   created () {
-    console.log('YO!')
     this.id = this.tableCount + 1
     this.createNewTable(this.id)
     this.importUserOptions()

--- a/src/components/filterable-table/FilterableTable.vue
+++ b/src/components/filterable-table/FilterableTable.vue
@@ -23,6 +23,7 @@
         :totalColumns="totalColumns"
       />
     </div>
+
     <div class="table-body">
       <template v-if="hasItems">
         <table-row v-for="item, itemIndex in items"
@@ -160,6 +161,7 @@ export default {
   },
 
   created () {
+    console.log('YO!')
     this.id = this.tableCount + 1
     this.createNewTable(this.id)
     this.importUserOptions()

--- a/src/components/filterable-table/TablePagination.vue
+++ b/src/components/filterable-table/TablePagination.vue
@@ -17,6 +17,7 @@
         @click="goToEnd('first')"
       >
         <svg-chevron class="button__svg" />
+
         <svg-chevron class="button__svg" />
       </button>
 
@@ -51,6 +52,7 @@
         @click="goToEnd('last')"
       >
         <svg-chevron class="button__svg" />
+
         <svg-chevron class="button__svg" />
       </button>
     </div>
@@ -65,11 +67,12 @@
 </template>
 
 <script>
-import SvgChevron from './svgs/SvgChevron.vue'
 import { createNamespacedHelpers } from 'vuex'
 import { range } from 'lodash'
 
 const { mapGetters, mapActions } = createNamespacedHelpers('filterableTable')
+
+import SvgChevron from './svgs/SvgChevron.vue'
 
 export default {
   name: "TablePagination",

--- a/src/components/filterable-table/TablePagination.vue
+++ b/src/components/filterable-table/TablePagination.vue
@@ -190,18 +190,17 @@ export default {
     ...mapActions({ updateRequestedPage: 'updateRequestedPage' }),
 
     changePage (isActive, direction) {
-      // only change the page if the button is active
-      if (isActive) {
-        const newPage = direction == 'next' ? this.currentPage + 1 : this.currentPage - 1
+      if (!isActive) return // only change the page if the button is active
+      
+      const newPage = direction == 'next' ? this.currentPage + 1 : this.currentPage - 1
 
-        const obj = { 
-          tableId: this.tableId,
-          requestedPage: newPage 
-        }
-
-        this.updateRequestedPage(obj)
-        this.$emit('updated:page')
+      const obj = { 
+        tableId: this.tableId,
+        requestedPage: newPage 
       }
+
+      this.updateRequestedPage(obj)
+      this.$emit('updated:page')
     },
 
     goToPage (page) {

--- a/src/components/filterable-table/TableRow.vue
+++ b/src/components/filterable-table/TableRow.vue
@@ -77,12 +77,13 @@
 </template>
 
 <script>
+import { createNamespacedHelpers } from 'vuex'
+
 import ArchiveButton from './ArchiveButton.vue'
 import SvgArrow from './svgs/SvgArrow.vue'
 import SvgEdit from './svgs/SvgEdit.vue'
 import TableCell from './TableCell.vue'
 import mixinColumns from './mixins/mixin-columns'
-import { createNamespacedHelpers } from 'vuex'
 
 const { mapGetters } = createNamespacedHelpers('filterableTable')
 

--- a/src/components/filterable-table/TableRow.vue
+++ b/src/components/filterable-table/TableRow.vue
@@ -12,7 +12,7 @@
       :disabled="archived"
     />
 
-    <table-cell 
+    <table-cell
       v-if="config.showArchived"
       :style="`grid-column: ${getAdminButtonColumn('archive')}`">
       <archive-button
@@ -30,10 +30,10 @@
       :disabled="archived"
     >
       <a
-        :class="getButtonClasses('edit')" 
+        :class="getButtonClasses('edit')"
         :href="item.editUrl"
       >
-        <portal-target 
+        <portal-target
           class="button__svg-wrapper"
           name="row-edit-icon"
         >
@@ -43,7 +43,7 @@
     </table-cell>
 
     <table-cell
-      v-if="this.isMoreContentColumnDisplayed(this.tableId)" 
+      v-if="this.isMoreContentColumnDisplayed(this.tableId)"
       :style="`grid-column: ${totalColumns}`"
       :disabled="archived"
     >
@@ -123,7 +123,7 @@ export default {
 
   data () {
     return {
-      archived: null
+      archived: this.item.archived
     }
   },
 

--- a/src/components/filterable-table/TableRow.vue
+++ b/src/components/filterable-table/TableRow.vue
@@ -121,11 +121,7 @@ export default {
     }
   },
 
-  created() {
-    this.archived = this.item.archived
-  },
-
-  data() {
+  data () {
     return {
       archived: null
     }
@@ -232,6 +228,12 @@ export default {
 
     updateArchiveStatus () {
       this.archived = !this.archived
+    }
+  },
+
+  watch: {
+    item () {
+      this.archived = this.item.archived
     }
   }
 }


### PR DESCRIPTION
## [Ticket 56: Archived Row Bug](https://unep-wcmc.codebasehq.com/projects/editable-loadable-filterable/tickets/56)

### Task

Fix the bug whereby an archived row would still be greyed out even when the page of the table is changed.

### Changes

I've fixed this by adding a watcher in the TableRow component. When its `item` prop is changed, its local `archived` state will update to reflect the archived state of the new item.

I've also made some tweaks to spacing around the place, nothing too controversial

### Testing

This can be slightly tricky to test since you need multiple pages of data and an app to test it in. Ideally, spin up a host application such as Indicator Repository, using the version of `wcmc-components` in the `fix/56-archived-row-bug` branch, and then play around with archiving items and changing pages. 

You should find:

- [x] Clicking the archive button greys out that row of the table after a negligible delay
- [x] Clicking it again will un-archive it, returning it to the normal colour of a table row
- [x] When you change page, a row containing an archived item will reflect the archived status of the new item, not the one from the previous page
- [ ] Returning back to the page where the archived item was, it will no longer be there, having been archived permanently

**Please contact me if you need any help setting up your testing environment with a host application using a local version of `wcmc-components`** :)