### PR TITLE
Ticket 55: Move New Record Button

### DIFF
--- a/src/components/filterable-table/FilterableTable.vue
+++ b/src/components/filterable-table/FilterableTable.vue
@@ -8,6 +8,15 @@
       <slot name="row-link-icon" />
     </portal>
 
+    <div
+      class='buttons'
+      v-if="shouldRenderNewRecordButton"
+    >
+      <new-record-button
+        :table-id="id"
+      />
+    </div>
+
     <table-filters
       :endpoint-download="endpointDownload"
       :filters="filters"
@@ -50,11 +59,6 @@
       :total-items="totalItems" 
       :total-pages="totalPages"
       v-on:updated:page="getNewItems"
-    />
-
-    <new-record-button
-      v-if="shouldRenderNewRecordButton"
-      :table-id="id"
     />
 
     <table-modal 
@@ -296,6 +300,13 @@ export default {
 <style lang="scss">
 * {
   box-sizing: border-box;
+}
+
+.buttons {
+  margin-bottom: 10px;
+  height: 50px;
+  
+  display: flex;
 }
 
 .cloak { display: none; }

--- a/src/components/filterable-table/NewRecordButton.vue
+++ b/src/components/filterable-table/NewRecordButton.vue
@@ -66,6 +66,7 @@ export default {
   background-color: #aaa;
   border-color: #009FE3;
   color: #fff;
+  font-family: Arial, Helvetica, sans-serif;
   font-size: 18px;
   font-weight: 500;
   padding-left: 24px;
@@ -90,6 +91,7 @@ export default {
   background-color: var(--bg-color);
   border-color: var(--border-color);
   color: var(--color);
+  font-family: var(--font-family);
   font-size: var(--font-size);
   font-weight: var(--font-weight);
   margin-bottom: rem-calc(10); // to sit inline with filters on mobile
@@ -97,6 +99,9 @@ export default {
   padding-left: var(--padding-left);
   padding-right: var(--padding-right);
   height: var(--height);
+
+  display: flex;
+  align-items: center;
 
   @include breakpoint($medium) { margin-bottom: 0; }
 

--- a/src/components/filterable-table/NewRecordButton.vue
+++ b/src/components/filterable-table/NewRecordButton.vue
@@ -60,39 +60,53 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
+// Styles here are only for IE11 
+.new-record-button {
+  background-color: #aaa;
+  border-color: #009FE3;
+  color: #fff;
+  font-size: 18px;
+  font-weight: 500;
+  padding-left: 24px;
+  padding-right: 24px; 
+  height: 50px;
+
+  &:hover {
+    background-color: #009FE3;
+    border-color: #009FE3; 
+  }
+}
+
+::v-deep .svg--download {
+  fill: '#fff';
+}
+
+// ------------------------------
+
+// Styles here either overwrite IE11 styles for other browsers, apply to all browsers
 .new-record-button {
   @include button-basic;
-  background-color: #aaa; // IE11
   background-color: var(--bg-color);
-  border-color: #009FE3; // IE11
   border-color: var(--border-color);
-  color: #fff; // IE11
   color: var(--color);
-  font-size: 18px;
   font-size: var(--font-size);
-  font-weight: 500;
   font-weight: var(--font-weight);
-  height: 50px; // IE11
-  height: var(--height);
-  margin-bottom: rem-calc(10); //to sit inline with filters on mobile
+  margin-bottom: rem-calc(10); // to sit inline with filters on mobile
   margin-left: auto;
-  padding-left: 24px; // IE11
   padding-left: var(--padding-left);
-  padding-right: 24px; // IE11
   padding-right: var(--padding-right);
+  height: var(--height);
 
   @include breakpoint($medium) { margin-bottom: 0; }
 
   &:hover {
-    background-color: #009FE3; // IE11
     background-color: var(--bg-color-hover);
-    border-color: #009FE3; // IE11
     border-color: var(--border-color-hover);
   }
 }
 
 ::v-deep .svg--download {
-  fill: '#fff'; // IE11
   fill: var(--icon-fill);
 }
 </style>


### PR DESCRIPTION
**Merge #69 before this one. This branch contains work from that PR, so it's better to merge that one first, so the base branch of this PR will automatically update to `develop`.**

## [Ticket 55: Move New Record Button](https://unep-wcmc.codebasehq.com/projects/editable-loadable-filterable/tickets/55)

### Task

Move the 'Add New Record' button to sit above the CSV download button, as indicated in the following screenshot:

![image](https://user-images.githubusercontent.com/56026099/216448322-071bc42f-062e-411a-b017-7395642420d6.png)

### Changes

The "new record" button has been moved up in the FilterableTable template, and some styles have been added/rearranged.

### Testing

This only really needs a visual check. As with all things `wcmc-components`, best done in integration with a host application, but just running `yarn serve` in this repository is probably also fine for this PR.

You should find:

- [ ] The font, spacing and colour of the button is in keeping with the other buttons around it.
- [ ] The button doesn't render unless the correct props are passed, namely `newRecordButton.url` & `newRecordButton.text` in the options prop.