### PR TITLE
Ticket 61: Stretching Archive Button Bug

### DIFF
--- a/src/components/filterable-table/ArchiveButton.vue
+++ b/src/components/filterable-table/ArchiveButton.vue
@@ -26,10 +26,12 @@ export default {
       type: String,
       required: true
     },
+    
     archived: {
       type: Boolean,
       required: true
     },
+    
     recordId: {
       type: Number,
       required: true
@@ -66,11 +68,10 @@ export default {
 
 <style lang="scss" scoped>
 .button {
-
   background: transparent;
   border: none;
   padding: 0;
-  width: 100%; height: 100%;
+  width: 100%; height: 80px;
   max-width: 80px; max-height: 80px;
 
   &:hover {


### PR DESCRIPTION
## [Ticket 61: Stretching Archive Button Bug](https://unep-wcmc.codebasehq.com/projects/editable-loadable-filterable/tickets/61)

### Task 

Fix the bug where the archive button would change size in rows of different heights

### Changes

Swap out a `height: 100%;` rule for `height: 80px;`

### Testing

Spin up the app, either with `yarn serve`, or integrated into a host application like Indicator Repository. Check the archive buttons. Are they all the same size? Enlarge or shrink one of the rows in your browser's devtools and ensure that the button remains the same size regardless of the height of the row it's in.

