### PR TITLE
fix: increase specificity of selector in ArchiveButton

### DIFF
--- a/src/components/filterable-table/ArchiveButton.vue
+++ b/src/components/filterable-table/ArchiveButton.vue
@@ -67,8 +67,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.button {
-
+.button.button--archive {
   background: transparent;
   border: none;
   padding: 0;


### PR DESCRIPTION
This is a slightly hacky solution to ensure that styles affecting the .button class in parent components won't affect the archive button